### PR TITLE
Add iCloud Airflow DAG and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
 # homeassistant-day-of-photos
-Provides day-of photos from cloud photo accounts to home assistant media directory for various uses. 
+
+This repository contains utilities for fetching "on this day" photos from
+cloud providers and copying them into Home Assistant's `media_source`. The
+original scripts used Google Photos, but `icloud_dag.py` demonstrates how to
+retrieve images from iCloud using Apache Airflow.
+
+## Requirements
+
+Install dependencies in a Python environment:
+
+```bash
+pip install -r requirements.txt
+```
+
+The Airflow DAG expects the `pyicloud-ipd` and `pillow` packages. Airflow itself
+should already be installed on the machine executing the DAG.
+
+## iCloud setup
+
+1. Enable two-factor authentication on your Apple account.
+2. Visit [appleid.apple.com](https://appleid.apple.com/) and create an
+   **app-specific password**. This password is used by the script to access
+your iCloud photos.
+3. On the machine running the DAG, set environment variables or Airflow
+   connection secrets with your Apple ID username and the app-specific
+   password.
+4. The first execution may prompt for the two-factor code. After the session is
+   cached, subsequent runs will use the stored session cookies.
+
+## Airflow usage
+
+The file `icloud_dag.py` defines a simple DAG named `icloud_day_photos`. It
+fetches photos from the same day over the last several years and stores them in
+an output directory. The DAG uses the `fetch_photos` function, which accepts:
+
+- `target_date`: date string (YYYY-MM-DD) for the day of interest.
+- `years_back`: how many years in the past to search.
+- `output_dir`: path where downloaded images are stored.
+- `username` and `password`: iCloud credentials.
+
+Example Airflow configuration:
+
+```python
+from icloud_dag import create_dag
+
+dag = create_dag(
+    name="icloud_day_photos",
+    schedule="0 5 * * *",
+    years_back=5,
+    output_dir="/srv/homeassistant/media/day_photos",
+    username="{{ var.value.ICLOUD_USERNAME }}",
+    password="{{ var.value.ICLOUD_PASSWORD }}",
+)
+```
+
+Place the file in your Airflow `dags/` folder. Airflow will run the task each
+morning and populate the output directory with photos.
+
+## Home Assistant configuration
+
+Ensure the `media_source` integration is enabled. Copy or mount the output
+folder from the Airflow machine to your Home Assistant instance. In `configuration.yaml`:
+
+```yaml
+homeassistant:
+  allowlist_external_dirs:
+    - /media/day_photos
+```
+
+Restart Home Assistant after updating the configuration. In WallPanel, set the
+background or image source to the media path containing the downloaded photos.
+
+## Filtering photos
+
+`icloud_dag.py` contains a placeholder `_is_interesting` function. It currently
+keeps images with a resolution greater than `800x600`. Replace this function
+with your preferred ML model or scoring logic to select only photos suitable for
+display.

--- a/icloud_dag.py
+++ b/icloud_dag.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+try:
+    from pyicloud import PyiCloudService  # type: ignore
+except ImportError:
+    PyiCloudService = None  # placeholder for type checking
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None  # placeholder
+
+
+def _is_interesting(image_path: Path) -> bool:
+    """Simple heuristic to keep only reasonably large photos.
+
+    Replace this function with a real model or scoring approach if available.
+    """
+    if Image is None:
+        return True
+
+    try:
+        with Image.open(image_path) as img:
+            width, height = img.size
+        return width * height >= 800 * 600
+    except Exception:
+        return False
+
+
+def fetch_photos(
+    target_date: Optional[str] = None,
+    years_back: int = 5,
+    output_dir: str = "./images",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> None:
+    """Fetch photos from iCloud and keep the interesting ones."""
+
+    if PyiCloudService is None:
+        raise RuntimeError(
+            "pyicloud is not installed. Install it with `pip install pyicloud-ipd`."
+        )
+
+    api = PyiCloudService(username, password)
+
+    if api.requires_2sa:
+        raise RuntimeError(
+            "Two-factor authentication is required. Set up a valid session before running.")
+
+    date = datetime.strptime(target_date, "%Y-%m-%d") if target_date else datetime.now()
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for year_offset in range(1, years_back + 1):
+        past = date.replace(year=date.year - year_offset)
+        start = past
+        end = past + timedelta(days=1)
+
+        photos = api.photos.search(start_date=start, end_date=end)
+        for photo in photos:
+            asset = photo.download()
+            file_name = f"{photo.id}.{photo.filename.split('.')[-1]}"
+            dest = out / file_name
+            asset.save(dest)
+            if not _is_interesting(dest):
+                dest.unlink(missing_ok=True)
+
+
+def create_dag(
+    name: str,
+    schedule: str = "0 5 * * *",
+    years_back: int = 5,
+    output_dir: str = "./images",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> DAG:
+    """Create a DAG that fetches day-of photos from iCloud."""
+    default_args = {"owner": "airflow", "retries": 1}
+    dag = DAG(name, schedule_interval=schedule, start_date=datetime(2024, 1, 1), default_args=default_args)
+
+    PythonOperator(
+        task_id="fetch_icloud_photos",
+        dag=dag,
+        python_callable=fetch_photos,
+        op_kwargs={
+            "target_date": "{{ ds }}",
+            "years_back": years_back,
+            "output_dir": output_dir,
+            "username": username,
+            "password": password,
+        },
+    )
+
+    return dag
+
+
+dag = create_dag("icloud_day_photos")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 google-auth-oauthlib
 google-api-python-client
 google-auth
+pyicloud-ipd
+pillow


### PR DESCRIPTION
## Summary
- add a DAG (`icloud_dag.py`) that fetches day-of photos from iCloud
- update requirements with pyicloud and pillow
- expand README with instructions for iCloud, Airflow, and Home Assistant

## Testing
- `python -m py_compile icloud_dag.py`
- `python -m py_compile rotate_images.py`


------
https://chatgpt.com/codex/tasks/task_e_68462c8e5760832ea799e010c8c76fd4