### PR TITLE
Handle 2FA without trusted devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,115 @@
 # homeassistant-day-of-photos
-Provides day-of photos from cloud photo accounts to home assistant media directory for various uses. 
+
+This repository contains utilities for fetching "on this day" photos from
+cloud providers and copying them into Home Assistant's `media_source`. The
+original scripts used Google Photos, but `icloud_dag.py` demonstrates how to
+retrieve images from iCloud using Apache Airflow.
+
+## Requirements
+
+Install dependencies in a Python environment:
+
+```bash
+pip install -r requirements.txt
+```
+
+The Airflow DAG expects the `pyicloud-ipd`, `pillow`, `opencv-python`, and
+`numpy` packages. Airflow itself should already be installed on the machine
+executing the DAG.
+
+## iCloud setup
+
+1. Enable two-factor authentication on your Apple account.
+2. Visit [appleid.apple.com](https://appleid.apple.com/) and create an
+   **app-specific password**. This password is used by the script to access
+your iCloud photos.
+3. On the machine running the DAG, set environment variables or Airflow
+   connection secrets with your Apple ID username and the app-specific
+   password.
+4. The first run may require a two-factor verification code. When prompted,
+   obtain the code from your trusted device and run the task with the
+   environment variable `ICLOUD_2FA_CODE` set to that code. Optionally set
+   `ICLOUD_2FA_DEVICE` to choose the trusted device index (default `0`). After a
+   successful login, the session cookie is saved and future runs will not need
+   the code until the cookie expires.
+
+## Airflow usage
+
+The file `icloud_dag.py` defines a simple DAG named `icloud_day_photos`. It
+fetches photos from the same day over the last several years and stores them in
+an output directory. The DAG uses the `fetch_photos` function, which accepts:
+
+- `target_date`: date string (YYYY-MM-DD) for the day of interest.
+- `years_back`: how many years in the past to search.
+- `output_dir`: path where downloaded images are stored.
+- `username` and `password`: iCloud credentials.
+
+Example Airflow configuration:
+
+```python
+from icloud_dag import create_dag
+
+dag = create_dag(
+    name="icloud_day_photos",
+    schedule="0 5 * * *",
+    years_back=5,
+    output_dir="/srv/homeassistant/media/day_photos",
+    username="{{ var.value.ICLOUD_USERNAME }}",
+    password="{{ var.value.ICLOUD_PASSWORD }}",
+)
+```
+
+Place the file in your Airflow `dags/` folder. Airflow will run the task each
+morning and populate the output directory with photos.
+
+To run the DAG manually from the command line:
+
+```bash
+airflow dags list          # confirm Airflow sees "icloud_day_photos"
+airflow dags trigger icloud_day_photos
+```
+
+## Home Assistant configuration
+
+Ensure the `media_source` integration is enabled. Copy or mount the output
+folder from the Airflow machine to your Home Assistant instance. In `configuration.yaml`:
+
+```yaml
+homeassistant:
+  allowlist_external_dirs:
+    - /media/day_photos
+```
+
+Restart Home Assistant after updating the configuration. In WallPanel, set the
+background or image source to the media path containing the downloaded photos.
+
+## Filtering photos
+
+`icloud_dag.py` implements a basic `_is_interesting` helper. Images smaller than
+`800x600` are discarded. If `opencv-python` is installed, the function attempts
+face detection using a bundled Haar cascade and automatically keeps photos with
+faces. For all other images, the script computes their grayscale entropy and
+retains those above a small threshold (≈5.0). You can replace this logic with a
+custom ML model if desired.
+
+## Troubleshooting iCloud access
+
+Use the `debug_icloud.py` script to verify your credentials and two-factor
+authentication setup outside of Airflow. Run it from the project directory:
+
+```bash
+python debug_icloud.py --download --years-back 2
+```
+
+The script prompts for your Apple ID username and app-specific password (unless
+`ICLOUD_USERNAME` and `ICLOUD_PASSWORD` environment variables are set). If
+two-factor authentication is required, enter the code when prompted. If you
+have multiple trusted devices and do not provide `ICLOUD_2FA_DEVICE`, the script
+will list the available devices and ask you to choose one. Images are
+downloaded into `./debug_images` by default so you can confirm everything works
+before scheduling the DAG.
+
+If the tool reports that no trusted devices are available, generate a
+verification code manually on your iPhone or Mac (Settings → your name →
+Password & Security → **Get Verification Code**) and pass it via the
+`ICLOUD_2FA_CODE` environment variable.

--- a/debug_icloud.py
+++ b/debug_icloud.py
@@ -1,0 +1,168 @@
+"""Command-line utility for checking iCloud photo access.
+
+This script allows manual login to iCloud using PyiCloudService, including the
+optional two-factor authentication step. It lists photos taken on the same day
+for a number of previous years and can optionally download them.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+from getpass import getpass
+from pathlib import Path
+import os
+from typing import Optional
+
+try:
+    from pyicloud import PyiCloudService  # type: ignore
+except ImportError:  # pragma: no cover - pyicloud may not be installed
+    PyiCloudService = None
+
+try:
+    from PIL import Image  # type: ignore
+except ImportError:  # pragma: no cover
+    Image = None
+
+try:
+    import cv2  # type: ignore
+    import numpy as np  # type: ignore
+    _FACE_CASCADE = cv2.CascadeClassifier(
+        cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+    )
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+    np = None
+    _FACE_CASCADE = None
+
+
+def _entropy(img: "Image.Image") -> float:
+    hist = img.histogram()
+    pixels = sum(hist)
+    if pixels == 0:
+        return 0.0
+    from math import log2
+
+    return -sum((h / pixels) * log2(h / pixels) for h in hist if h)
+
+
+def _is_interesting(path: Path) -> bool:
+    """Heuristic filter to skip non-photo images."""
+    if Image is None:
+        return True
+
+    try:
+        with Image.open(path) as img:
+            w, h = img.size
+            if w < 800 or h < 600:
+                return False
+
+            if cv2 is not None and np is not None and _FACE_CASCADE is not None:
+                arr = cv2.cvtColor(np.array(img.convert("RGB")), cv2.COLOR_RGB2BGR)
+                gray = cv2.cvtColor(arr, cv2.COLOR_BGR2GRAY)
+                faces = _FACE_CASCADE.detectMultiScale(gray, 1.1, 5)
+                if len(faces) > 0:
+                    return True
+
+            entropy = _entropy(img.convert("L"))
+            return entropy >= 5.0
+    except Exception:
+        return False
+
+
+def _login(username: str, password: str) -> "PyiCloudService":
+    if PyiCloudService is None:
+        raise RuntimeError("pyicloud-ipd is not installed")
+
+    api = PyiCloudService(username, password)
+    if api.requires_2sa:
+        devices = api.trusted_devices
+        if not devices:
+            # Some accounts do not return devices. Allow a manually generated
+            # verification code instead of failing immediately.
+            code = os.environ.get("ICLOUD_2FA_CODE") or input("Enter 2FA code: ")
+            if not code:
+                raise RuntimeError(
+                    "Two-factor code required but no trusted devices found. "
+                    "Generate a code on a trusted device and set ICLOUD_2FA_CODE."
+                )
+            if not api.validate_verification_code(None, code):
+                raise RuntimeError("Failed to verify 2FA code")
+            try:
+                api.trust_session()
+            except Exception:
+                pass
+            return api
+
+        index_env = os.environ.get("ICLOUD_2FA_DEVICE")
+        if index_env is None and len(devices) > 1:
+            print("Trusted devices:")
+            for i, d in enumerate(devices):
+                name = d.get("deviceName") or d.get("name") or str(d)
+                print(f"  [{i}] {name}")
+            index_env = input("Select device index: ") or "0"
+
+        index = int(index_env or 0)
+        if index < 0 or index >= len(devices):
+            raise RuntimeError("Invalid 2FA device index")
+
+        device = devices[index]
+        if not api.send_verification_code(device):
+            raise RuntimeError("Failed to send verification code")
+        code = os.environ.get("ICLOUD_2FA_CODE") or input("Enter 2FA code: ")
+        if not api.validate_verification_code(device, code):
+            raise RuntimeError("Failed to verify 2FA code")
+        try:
+            api.trust_session()
+        except Exception:
+            pass
+    return api
+
+
+def _search(api: "PyiCloudService", when: datetime) -> list:
+    start = when
+    end = when + timedelta(days=1)
+    return list(api.photos.search(start_date=start, end_date=end))
+
+
+def _download(asset, dest: Path) -> None:
+    file_name = f"{asset.id}.{asset.filename.split('.')[-1]}"
+    path = dest / file_name
+    asset.download().save(path)
+    if not _is_interesting(path):
+        path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manually fetch iCloud photos")
+    parser.add_argument("--target-date", default=datetime.now().strftime("%Y-%m-%d"))
+    parser.add_argument("--years-back", type=int, default=5)
+    parser.add_argument("--output-dir", default="./debug_images")
+    parser.add_argument("--download", action="store_true", help="Download images")
+    args = parser.parse_args()
+
+    username = os.environ.get("ICLOUD_USERNAME") or input("iCloud username: ")
+    password = os.environ.get("ICLOUD_PASSWORD") or getpass("App-specific password: ")
+
+    api = _login(username, password)
+    date = datetime.strptime(args.target_date, "%Y-%m-%d")
+
+    if args.download:
+        out = Path(args.output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+    for offset in range(1, args.years_back + 1):
+        past = date.replace(year=date.year - offset)
+        print(f"Searching {past.date()}...", end="")
+        photos = _search(api, past)
+        print(f" found {len(photos)} photos")
+        if args.download:
+            for p in photos:
+                _download(p, out)
+
+    if args.download:
+        print(f"Saved images to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/icloud_dag.py
+++ b/icloud_dag.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+import os
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+try:
+    from pyicloud import PyiCloudService  # type: ignore
+except ImportError:
+    PyiCloudService = None  # placeholder for type checking
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None  # placeholder
+
+try:
+    import cv2  # type: ignore
+    import numpy as np  # type: ignore
+    _FACE_CASCADE = cv2.CascadeClassifier(
+        cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+    )
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None  # type: ignore
+    np = None  # type: ignore
+    _FACE_CASCADE = None
+
+
+def _entropy(img: "Image.Image") -> float:
+    """Return the Shannon entropy of a Pillow image."""
+    hist = img.histogram()
+    pixels = sum(hist)
+    if pixels == 0:
+        return 0.0
+    from math import log2
+
+    return -sum((h / pixels) * log2(h / pixels) for h in hist if h)
+
+
+def _is_interesting(image_path: Path) -> bool:
+    """Heuristic to skip screenshots or low-quality photos."""
+    if Image is None:
+        return True
+
+    try:
+        with Image.open(image_path) as img:
+            width, height = img.size
+            if width < 800 or height < 600:
+                return False
+
+            img_rgb = img.convert("RGB")
+
+            if cv2 is not None and np is not None and _FACE_CASCADE is not None:
+                arr = cv2.cvtColor(np.array(img_rgb), cv2.COLOR_RGB2BGR)
+                gray = cv2.cvtColor(arr, cv2.COLOR_BGR2GRAY)
+                faces = _FACE_CASCADE.detectMultiScale(gray, 1.1, 5)
+                if len(faces) > 0:
+                    return True
+
+            entropy = _entropy(img_rgb.convert("L"))
+            return entropy >= 5.0
+    except Exception:
+        return False
+
+
+def _login(username: str | None, password: str | None) -> "PyiCloudService":
+    """Return an authenticated PyiCloudService instance, handling 2FA."""
+    api = PyiCloudService(username, password)
+
+    if api.requires_2sa:
+        code = os.environ.get("ICLOUD_2FA_CODE")
+        device_index = int(os.environ.get("ICLOUD_2FA_DEVICE", "0"))
+        if not code:
+            raise RuntimeError(
+                "Two-factor code required. Set ICLOUD_2FA_CODE environment variable"
+            )
+
+        devices = api.trusted_devices
+        if not devices:
+            # Some accounts do not return devices. Allow manual verification
+            # instead of failing immediately.
+            if not api.validate_verification_code(None, code):
+                raise RuntimeError(
+                    "Two-factor code required but no trusted devices found. "
+                    "Generate a code on a trusted device and set ICLOUD_2FA_CODE."
+                )
+            try:
+                api.trust_session()
+            except Exception:
+                pass
+            return api
+
+        if device_index < 0 or device_index >= len(devices):
+            raise RuntimeError("Invalid 2FA device index")
+
+        device = devices[device_index]
+        if not api.send_verification_code(device):
+            raise RuntimeError("Failed to send verification code")
+        if not api.validate_verification_code(device, code):
+            raise RuntimeError("Failed to verify the provided 2FA code")
+        try:
+            api.trust_session()
+        except Exception:
+            pass
+
+    return api
+
+
+def fetch_photos(
+    target_date: Optional[str] = None,
+    years_back: int = 5,
+    output_dir: str = "./images",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> None:
+    """Fetch photos from iCloud and keep the interesting ones."""
+
+    if PyiCloudService is None:
+        raise RuntimeError(
+            "pyicloud is not installed. Install it with `pip install pyicloud-ipd`."
+        )
+
+    api = _login(username, password)
+
+    date = datetime.strptime(target_date, "%Y-%m-%d") if target_date else datetime.now()
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for year_offset in range(1, years_back + 1):
+        past = date.replace(year=date.year - year_offset)
+        start = past
+        end = past + timedelta(days=1)
+
+        photos = api.photos.search(start_date=start, end_date=end)
+        for photo in photos:
+            asset = photo.download()
+            file_name = f"{photo.id}.{photo.filename.split('.')[-1]}"
+            dest = out / file_name
+            asset.save(dest)
+            if not _is_interesting(dest):
+                dest.unlink(missing_ok=True)
+
+
+def create_dag(
+    name: str,
+    schedule: str = "0 5 * * *",
+    years_back: int = 5,
+    output_dir: str = "./images",
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> DAG:
+    """Create a DAG that fetches day-of photos from iCloud."""
+    default_args = {"owner": "airflow", "retries": 1}
+    dag = DAG(name, schedule_interval=schedule, start_date=datetime(2024, 1, 1), default_args=default_args)
+
+    PythonOperator(
+        task_id="fetch_icloud_photos",
+        dag=dag,
+        python_callable=fetch_photos,
+        op_kwargs={
+            "target_date": "{{ ds }}",
+            "years_back": years_back,
+            "output_dir": output_dir,
+            "username": username,
+            "password": password,
+        },
+    )
+
+    return dag
+
+
+dag = create_dag("icloud_day_photos")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ requests
 google-auth-oauthlib
 google-api-python-client
 google-auth
+pyicloud-ipd
+pillow
+numpy
+opencv-python


### PR DESCRIPTION
## Summary
- let login functions accept a manual 2FA code when iCloud returns no trusted devices
- document the fallback in the troubleshooting section

## Testing
- `python -m py_compile icloud_dag.py rotate_images.py debug_icloud.py`


------
https://chatgpt.com/codex/tasks/task_e_68462c8e5760832ea799e010c8c76fd4